### PR TITLE
Scale mouse sprites and adjust hitbox

### DIFF
--- a/game.js
+++ b/game.js
@@ -144,11 +144,18 @@
   }
 
   function spawnMouse(){
+    const SCALE = 1.3;
+    const margin = 80 * SCALE;
     const isGolden = Math.random() < 0.05;
-    const m = scene.physics.add.sprite(80+Math.random()*(WORLD.w-160), 80+Math.random()*(WORLD.h-160), 'mouse').play('mouse_run');
+    const m = scene.physics.add
+      .sprite(margin + Math.random() * (WORLD.w - margin * 2),
+              margin + Math.random() * (WORLD.h - margin * 2),
+              'mouse')
+      .play('mouse_run');
+    m.setScale(SCALE);
     if(isGolden) m.setTint(0xffd700);
-    const d = 36;
-    m.setCircle(d / 2, (56 - d) / 2, (36 - d) / 2); // 36px diameter centered in 56×36 sprite
+    const d = 36 * SCALE;
+    m.setCircle(d / 2, (56 * SCALE - d) / 2, (36 * SCALE - d) / 2); // scaled 36px diameter centered in 56×36 sprite
     m.base = 120 + Math.random()*40;
     m.dir = new Phaser.Math.Vector2((Math.random()*2-1),(Math.random()*2-1)).normalize();
     m.body.setVelocity(m.dir.x*m.base, m.dir.y*m.base);


### PR DESCRIPTION
## Summary
- enlarge mouse sprites with a configurable scale and update hitbox accordingly
- expand spawn margin based on scale to prevent clipping at world edges

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bb5de55948326a9b3b6bd79256c29