### PR TITLE
Add particle burst and vibration on mouse catch

### DIFF
--- a/game.js
+++ b/game.js
@@ -250,7 +250,30 @@
     for (let i = 0; i < maxMice(); i++) spawnMouse();
 
     scene.physics.add.collider(loki, obstGroup);
-    scene.physics.add.overlap(loki, miceGroup, (cat, m)=>{ m.destroy(); countL++; xp++; if(sfxToggle.checked){ sCatch.currentTime=0; sCatch.play(); } updHUD(); checkEnd(); });
+    scene.physics.add.overlap(loki, miceGroup, (cat, m)=>{
+      const { x, y } = m;
+      m.destroy();
+      // Particle burst at the mouse position
+      const particles = scene.add.particles('mouse');
+      const emitter = particles.createEmitter({
+        frame: 0,
+        speed: { min: -200, max: 200 },
+        scale: { start: 0.6, end: 0 },
+        lifespan: 300,
+        quantity: 10
+      })
+      emitter.explode(10, x, y);
+      scene.time.delayedCall(300, () => particles.destroy());
+      if (navigator.vibrate) navigator.vibrate(100);
+      countL++;
+      xp++;
+      if (sfxToggle.checked) {
+        sCatch.currentTime = 0;
+        sCatch.play();
+      }
+      updHUD();
+      checkEnd();
+    });
 
     scene.cameras.main.startFollow(loki, false, 0.5, 0.5);
   }


### PR DESCRIPTION
## Summary
- Create particle burst at mouse catch location
- Vibrate device briefly upon catching a mouse

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bb5dc62588326b03a53b49188674c