### PR TITLE
Scale mouse spawn count per level

### DIFF
--- a/game.js
+++ b/game.js
@@ -84,9 +84,11 @@
   let scene, layers=null, loki, merlin=null, yumi=null, miceGroup, obstGroup;
   let keys;
   let jdx=0,jdy=0, swipeActive=false, swipeStart=null;
-  const BASE_MICE = /iPhone|iPad|iPod/.test(navigator.userAgent)?80:100;
+  const BASE_MICE = /iPhone|iPad|iPod/.test(navigator.userAgent)?800:1000;
+  const DECAY_RATE = 0.9; // 10% fewer mice each level
+  const MIN_MICE = 10;
   const lokiStats = { speed: 1000 };
-  const maxMice = () => Math.floor(BASE_MICE * (1 + 0.5*(lvl-1)));
+  const maxMice = () => Math.max(MIN_MICE, Math.floor(BASE_MICE * DECAY_RATE ** (lvl - 1)));
 
   function preload(){
     scene=this;


### PR DESCRIPTION
## Summary
- Start level 1 with a large mouse population and reduce by 10% each level
- Maintain a minimum of ten mice regardless of level

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bb5d893108326b425fe39f798e8ca