### PR TITLE
Handle unsupported vibration in mouse catch to avoid crashes

### DIFF
--- a/game.js
+++ b/game.js
@@ -263,17 +263,27 @@
       const { x, y } = m;
       m.destroy();
       // Particle burst at the mouse position
-      const particles = scene.add.particles('mouse');
-      const emitter = particles.createEmitter({
-        frame: 0,
-        speed: { min: -200, max: 200 },
-        scale: { start: 0.6, end: 0 },
-        lifespan: 300,
-        quantity: 10
-      })
-      emitter.explode(10, x, y);
-      scene.time.delayedCall(300, () => particles.destroy());
-      if (navigator.vibrate) navigator.vibrate(100);
+      try {
+        const particles = scene.add.particles('mouse');
+        const emitter = particles.createEmitter({
+          frame: 0,
+          speed: { min: -200, max: 200 },
+          scale: { start: 0.6, end: 0 },
+          lifespan: 300,
+          quantity: 10
+        });
+        emitter.explode(10, x, y);
+        scene.time.delayedCall(300, () => particles.destroy());
+      } catch (err) {
+        console.warn('Particle effect failed', err);
+      }
+      try {
+        if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+          navigator.vibrate(100);
+        }
+      } catch (err) {
+        console.warn('Vibration failed', err);
+      }
       countL++;
       xp++;
       if (sfxToggle.checked) {

--- a/game.test.js
+++ b/game.test.js
@@ -65,9 +65,9 @@ describe('catchMouse', () => {
   const code = fs.readFileSync(__dirname + '/game.js', 'utf8');
 
   test('overlap destroys mouse and increments counters', () => {
-    const overlap = code.match(/scene\.physics\.add\.overlap\(loki,\s*miceGroup,\s*\(cat,\s*m\)=>\{[^]*?\}\);/);
-    expect(overlap).not.toBeNull();
-    const body = overlap[0];
+    const idx = code.indexOf('scene.physics.add.overlap(loki, miceGroup');
+    expect(idx).toBeGreaterThan(-1);
+    const body = code.slice(idx, code.indexOf('checkEnd();', idx));
     expect(body).toMatch(/m\.destroy\(\)/);
     expect(body).toMatch(/countL\+\+/);
     expect(body).not.toMatch(/goalCaught\+\+/);


### PR DESCRIPTION
## Summary
- wrap particle splash and vibration in try/catch so unsupported devices don't crash when a mouse is caught
- adjust catchMouse test to match new overlap code

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c30cd74448326baf41b1e7c1c6140