### PR TITLE
Align mouse hitboxes and raise level goals

### DIFF
--- a/game.js
+++ b/game.js
@@ -28,7 +28,7 @@
   const skillbar = document.querySelector('.skillbar');
   let gameReady = false;
 
-  const INITIAL_GOAL = 15;
+  const INITIAL_GOAL = 40;
     let state='menu',lvl=1,goal=INITIAL_GOAL;
     let countL=0,countM=0,countY=0,xp=0;
     function updHUD(){ cL.textContent=countL; cM.textContent=countM; cY.textContent=countY; lvlEl.textContent=lvl; goalNeed.textContent=goal; goalLeft.textContent=Math.max(0, goal-countL); xpEl.textContent=xp; }
@@ -148,7 +148,7 @@
   function spawnMouse(){
     const SCALE = 2.7; // 50% larger sprite
     const margin = 80 * SCALE;
-    const hitbox = 36 * SCALE * 0.6; // reduce hitbox for fairer collisions
+    const hitboxScale = 0.6; // shrink hitbox for precise collisions
     const isGolden = Math.random() < 0.05;
     const m = scene.physics.add
       .sprite(margin + Math.random() * (WORLD.w - margin * 2),
@@ -157,7 +157,7 @@
       .play('mouse_run');
     m.setScale(SCALE);
     if(isGolden) m.setTint(0xffd700);
-    m.setCircle(hitbox / 2, (56 * SCALE - hitbox) / 2, (36 * SCALE - hitbox) / 2); // 60% of scaled sprite height
+    m.body.setSize(m.displayWidth * hitboxScale, m.displayHeight * hitboxScale, true);
     m.base = 120 + Math.random()*40;
     m.dir = new Phaser.Math.Vector2((Math.random()*2-1),(Math.random()*2-1)).normalize();
     m.body.setVelocity(m.dir.x*m.base, m.dir.y*m.base);
@@ -199,7 +199,8 @@
 
   function nextLevel(){
     lvl++;
-    goal = Math.floor(goal*1.1); countL=0; countM=0; countY=0;
+    goal += 20;
+    countL=0; countM=0; countY=0;
     applyLevelUp();
     updHUD();
     resetWorld();

--- a/game.test.js
+++ b/game.test.js
@@ -29,7 +29,7 @@ describe('saveSlot and loadSlot', () => {
     };
     vm.createContext(context);
     vm.runInContext(`
-        var lvl=1, goal=15;
+        var lvl=1, goal=40;
         var countL=0, countM=0, countY=0, xp=0;
       ${safeGetCode}
       ${safeSetCode}
@@ -121,7 +121,7 @@ describe('nextLevel', () => {
     context.applyLevelUp = () => { context.applied = true; };
     vm.createContext(context);
     vm.runInContext(`
-      var lvl=1, goal=15, countL=1, countM=2, countY=3;
+      var lvl=1, goal=40, countL=1, countM=2, countY=3;
       ${nextLevelCode}
     `, context);
 

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     <span class="pill">Merlin: <b id="cM">0</b></span>
     <span class="pill">Yumi: <b id="cY">0</b></span>
     <span class="pill">Level: <b id="lvl">1</b></span>
-    <span class="pill">Ziel: <b id="goalNeed">15</b> (Rest <b id="goalLeft">15</b>)</span>
+    <span class="pill">Ziel: <b id="goalNeed">40</b> (Rest <b id="goalLeft">40</b>)</span>
     <span class="pill">XP: <b id="xp">0</b></span>
     <span class="pill" id="statMsg" style="display:none"></span>
   <span class="pill" style="margin-left:auto"><button id="btnPause">Pause</button> <button id="btnRestart">Neu</button> <button id="btnMenu">Menü</button> <button id="btnMap">🗺️</button> <button id="btnMute">🔊</button></span>


### PR DESCRIPTION
## Summary
- shrink and center mouse hitbox to prevent early or missed catches
- start with 40 mice goal and add 20 per level
- update HUD defaults and tests for new goal values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca3b44fac8326a3de64758182596c